### PR TITLE
Update bitrise-init, bump version

### DIFF
--- a/bitrise-plugin.yml
+++ b/bitrise-plugin.yml
@@ -2,9 +2,9 @@ name: init
 description: Initialize bitrise __config (bitrise.yml)__ and __secrets (.bitrise.secrets.yml)__
   based on your project.
 executable:
-  osx: https://github.com/bitrise-io/bitrise-plugins-init/releases/download/1.3.6/bitrise-plugins-init-Darwin-x86_64
-  osx-arm64: https://github.com/bitrise-io/bitrise-plugins-init/releases/download/1.3.6/bitrise-plugins-init-Darwin-arm64
-  linux: https://github.com/bitrise-io/bitrise-plugins-init/releases/download/1.3.6/bitrise-plugins-init-Linux-x86_64
+  osx: https://github.com/bitrise-io/bitrise-plugins-init/releases/download/1.4.0/bitrise-plugins-init-Darwin-x86_64
+  osx-arm64: https://github.com/bitrise-io/bitrise-plugins-init/releases/download/1.4.0/bitrise-plugins-init-Darwin-arm64
+  linux: https://github.com/bitrise-io/bitrise-plugins-init/releases/download/1.4.0/bitrise-plugins-init-Linux-x86_64
 trigger: ""
 requirements:
 - tool: bitrise

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/bitrise-io/bitrise v0.0.0-20210623145422-513e39485248
-	github.com/bitrise-io/bitrise-init v0.0.0-20210726124629-228da329b98c
+	github.com/bitrise-io/bitrise-init v0.0.0-20210825103211-215b191850fd
 	github.com/bitrise-io/envman v0.0.0-20210630102032-df85af51bd1a
 	github.com/bitrise-io/go-steputils v0.0.0-20210527075147-910ce7a105a1 // indirect
 	github.com/bitrise-io/go-utils v0.0.0-20210713111255-08be784d45d0

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/beevik/etree v1.1.0/go.mod h1:r8Aw8JqVegEf0w2fDnATrX9VpkMcyFeM0FhwO62
 github.com/bitrise-io/bitrise v0.0.0-20210519130014-380842fb41c1/go.mod h1:Jqf2PLwOKL1bYdbQIhVkNd55YyYKJBXyY0EtlRg5uw4=
 github.com/bitrise-io/bitrise v0.0.0-20210623145422-513e39485248 h1:GfhBF379/Uwu4fmalhwwoJv3RcqlrlEo8+gGEcuXLsw=
 github.com/bitrise-io/bitrise v0.0.0-20210623145422-513e39485248/go.mod h1:jqk9VdrvlRpRfIqA2DZHVNEMvPycmlpBfpiKxk89R6w=
-github.com/bitrise-io/bitrise-init v0.0.0-20210726124629-228da329b98c h1:ljFAGTCtfh5+TJPYPp5Hi1fXdVtklvZWlMMjB5N+BFI=
-github.com/bitrise-io/bitrise-init v0.0.0-20210726124629-228da329b98c/go.mod h1:I9KSWJm177/IOBMQHzn6BLgymVLQ0xlv/gMwDCYkWYU=
+github.com/bitrise-io/bitrise-init v0.0.0-20210825103211-215b191850fd h1:obnQgrwXEdQWZExnRwtEh41b05jSNhvJoCl5OFPY9w0=
+github.com/bitrise-io/bitrise-init v0.0.0-20210825103211-215b191850fd/go.mod h1:I9KSWJm177/IOBMQHzn6BLgymVLQ0xlv/gMwDCYkWYU=
 github.com/bitrise-io/colorstring v0.0.0-20180614154802-a8cd70115192/go.mod h1:CIHVcxZUvsG99XUJV6JlR7okNsMMGY81jMvPC20W+O0=
 github.com/bitrise-io/envman v0.0.0-20200512105748-919e33f391ee/go.mod h1:m8pTp1o3Sw9uzDxb1WRm5IBRnMau2iOvPMSnRCAhQNI=
 github.com/bitrise-io/envman v0.0.0-20210517135508-b2b4fe89eac5/go.mod h1:m8pTp1o3Sw9uzDxb1WRm5IBRnMau2iOvPMSnRCAhQNI=

--- a/vendor/github.com/bitrise-io/bitrise-init/steps/const.go
+++ b/vendor/github.com/bitrise-io/bitrise-init/steps/const.go
@@ -25,7 +25,7 @@ const (
 	// AndroidBuildID ...
 	AndroidBuildID = "android-build"
 	// AndroidBuildVersion ...
-	AndroidBuildVersion = "0"
+	AndroidBuildVersion = "1"
 )
 
 const (

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -3,7 +3,7 @@ github.com/beevik/etree
 # github.com/bitrise-io/bitrise v0.0.0-20210623145422-513e39485248
 ## explicit
 github.com/bitrise-io/bitrise/models
-# github.com/bitrise-io/bitrise-init v0.0.0-20210726124629-228da329b98c
+# github.com/bitrise-io/bitrise-init v0.0.0-20210825103211-215b191850fd
 ## explicit
 github.com/bitrise-io/bitrise-init/analytics
 github.com/bitrise-io/bitrise-init/errormapper

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // VERSION ...
-const VERSION = "1.3.7"
+const VERSION = "1.4.0"


### PR DESCRIPTION
### Context

Upgrading the Android Build step to version 1.x in all workflows: https://github.com/bitrise-steplib/bitrise-step-android-build/releases/1.0.0